### PR TITLE
Fix NULL error

### DIFF
--- a/lua/precision_align/core/physgun_precision.lua
+++ b/lua/precision_align/core/physgun_precision.lua
@@ -4,7 +4,7 @@ if SERVER then
     end
 
     hook.Add("OnPhysgunFreeze", "PA_FixPhysgunRotationInaccuracy", function(_, PhysObj, _, Player)
-        if not Player:KeyDown(IN_SPEED) then return end
+        if not Player:KeyDown(IN_SPEED) or not PhysObj:IsValid() then return end
         local ShouldSnap = Player:GetInfo("precision_align_snap_physgun")
         if ShouldSnap == 0 then return end
 


### PR DESCRIPTION
PhysObj can easily be invalid if, for example, you are trying to freeze an NPC
```
- lua/precision_align/core/physgun_precision.lua:12: Tried to use a NULL physics object!
1. GetAngles - [C]:-1
 2. <unknown> - lua/precision_align/core/physgun_precision.lua:12
  3. <unknown> - addons/hook-library-master/lua/includes/modules/hook.lua:313
```